### PR TITLE
Chore (changes) Added target blank of Social icons to swift on new tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -947,7 +947,7 @@
                 </div>
                 <p>Latest from Linkedin</p>
                 <p>Here you will find all my latest achievements, DevOps projects, and posts that I have created.</p>
-                <a href="https://linkedin.com/in/md-azfar-alam" class="btn btn-inverted">follow me</a>
+                <a href="https://linkedin.com/in/md-azfar-alam" target="_blank" class="btn btn-inverted">follow me</a>
             </div>
         </section><!-- /.section-twitter-->
         <!-- End Twitter section --> 
@@ -985,22 +985,22 @@
         <!-- Social Networks section --> 
         <section class="section-networks blue-bg">
             <div class="container">
-                <a href="https://linkedin.com/in/md-azfar-alam" class="rectangle">
+                <a href="https://linkedin.com/in/md-azfar-alam" target="_blank" class="rectangle">
                     <i class="fa fa-linkedin"></i>
                 </a>
-                <a href="https://github.com/mdazfar2" class="rectangle">
+                <a href="https://github.com/mdazfar2" target="_blank" class="rectangle">
                     <i class="fa fa-github"></i>
                 </a>
-                <a href="https://instagram.com/azfarxx_" class="rectangle">
+                <a href="https://instagram.com/azfarxx_" target="_blank" class="rectangle">
                     <i class="fa fa-instagram"></i>
                 </a>
-                <a href="https://twitter.com/AzfarAlam22" class="rectangle">
+                <a href="https://twitter.com/AzfarAlam22" target="_blank" class="rectangle">
                     <i class="fa fa-twitter"></i>
                 </a>
-                <a href="mailto:azfaralam.ops@gmail.com" class="rectangle">
+                <a href="mailto:azfaralam.ops@gmail.com" target="_blank" class="rectangle">
                     <i class="fa fa-envelope"></i>
                 </a>
-                <a href="https://www.facebook.com/mdazfar2" class="rectangle">
+                <a href="https://www.facebook.com/mdazfar2" target="_blank" class="rectangle">
                     <i class="fa fa-facebook"></i>
                 </a>
             </div>


### PR DESCRIPTION
## Add `target="_blank"` to Social Links for New Tab Opening

### Description:
This pull request modifies the social media links to include `target="_blank"`, ensuring they open in a new tab when clicked. This enhancement improves user experience by allowing users to stay on the main website while exploring social links in a separate tab.

### Changes Made:
- Added `target="_blank"` to all social media links.
- Ensured consistent behavior across all social links in the footer/header (or wherever applicable).

### Why this change is necessary:
- Opening external links (especially social media) in a new tab prevents users from unintentionally navigating away from the main site.
- Enhances user engagement and retention by keeping the current session active.

### Testing:
- Verified that each social link correctly opens in a new tab.
- Checked for compatibility across different browsers.